### PR TITLE
Post-Release Polish

### DIFF
--- a/Arduino/DJSpinRhythm/DJSpinRhythm.ino
+++ b/Arduino/DJSpinRhythm/DJSpinRhythm.ino
@@ -71,7 +71,7 @@ void setup() {
 
 	#if defined(USB_SERIAL_HID) || defined(__AVR_ATmega32U4__)
 	Serial.begin(115200);
-	Serial.println("DJ Hero - Spin Rhythm XD Controller v1.0.0");
+	Serial.println("DJ Hero - Spin Rhythm XD Controller v1.0.1");
 	Serial.println("By David Madison, (c) 2020");
 	Serial.println("http://www.partsnotincluded.com");
 	Serial.println("----------------------------");

--- a/Arduino/DJSpinRhythm/DJSpinRhythm.ino
+++ b/Arduino/DJSpinRhythm/DJSpinRhythm.ino
@@ -65,16 +65,16 @@ KeyboardButton navigateRight('d');
 EffectHandler fx(dj, EffectsTimeout);
 
 void setup() {
+	#ifdef DEBUG
+	while (!Serial);  // Wait for connection
+	#endif
+
 	#if defined(USB_SERIAL_HID) || defined(__AVR_ATmega32U4__)
 	Serial.begin(115200);
 	Serial.println("DJ Hero - Spin Rhythm XD Controller v1.0.0");
 	Serial.println("By David Madison, (c) 2020");
 	Serial.println("http://www.partsnotincluded.com");
 	Serial.println("----------------------------");
-	#endif
-
-	#ifdef DEBUG
-	while (!Serial);  // Wait for connection
 	#endif
 
 	pinMode(SafetyPin, INPUT_PULLUP);

--- a/Arduino/DJSpinRhythm/DJSpinRhythm.ino
+++ b/Arduino/DJSpinRhythm/DJSpinRhythm.ino
@@ -164,14 +164,14 @@ void moveWheel(int8_t xIn) {
 	if (abs(xIn) >= MaxWheelInput) xIn = lastAim;
 	else lastAim = xIn;
 
+	if (xIn == 0) return;  // 0 input, don't send packet
+
 	Mouse.move(xIn * WheelSensitivity, 0);
 
 	#ifdef DEBUG_HID
-	if (xIn != 0) {
-		DEBUG_PRINT("Moved the mouse {");
-		DEBUG_PRINT(xIn * WheelSensitivity);
-		DEBUG_PRINTLN(", 0}");
-	}
+	DEBUG_PRINT("Moved the mouse {");
+	DEBUG_PRINT(xIn * WheelSensitivity);
+	DEBUG_PRINTLN(", 0}");
 	#endif
 }
 


### PR DESCRIPTION
There's always something, right?

This is a quick PR to fix the "debug" output to include the "by" lines. Because the `!Serial` catch was after the prints those lines would print when the microcontroller initialized, before the serial interface was opened.

This also adds a check to prevent enqueuing USB mouse packets if the mouse isn't being moved that update. No functional change, it's just cleaner and easier on the host.